### PR TITLE
Fix login/signup not updating auth context

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,16 +2,18 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { login } = useAuth();
 
   const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // Mock login logic
-    console.log("Login attempt");
-    // In a real app, you'd call your auth context login function here
-    // For now, we'll just redirect to a placeholder dashboard
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+    login(email, password);
     router.push("/dashboard");
   };
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -2,16 +2,22 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function SignupPage() {
   const router = useRouter();
+  const { signup } = useAuth();
 
   const handleSignup = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // Mock signup logic
-    console.log("Signup attempt");
-    // In a real app, you'd call your auth context signup function here
-    // For now, we'll just redirect to a placeholder dashboard
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string; // Ignored in mock
+    const grade = formData.get("grade") as string;
+    const gender = formData.get("gender") as string;
+    const dormitory = formData.get("dormitory") as string;
+
+    signup({ email, grade, gender, dormitory });
     router.push("/dashboard");
   };
 


### PR DESCRIPTION
## Summary
- ensure login page calls AuthContext login
- ensure signup page calls AuthContext signup

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa35c328c8323baf4e4c005a87563