### PR TITLE
Implement persistent auth state

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
 interface User {
   email: string;
@@ -23,6 +23,36 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [user, setUser] = useState<User | null>(null);
 
+  // Load saved authentication state on first render
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storedAuth = localStorage.getItem('isAuthenticated');
+    const storedUser = localStorage.getItem('authUser');
+    if (storedAuth === 'true' && storedUser) {
+      try {
+        const parsedUser: User = JSON.parse(storedUser);
+        setUser(parsedUser);
+        setIsAuthenticated(true);
+      } catch (err) {
+        console.error('Failed to parse stored user', err);
+        localStorage.removeItem('authUser');
+        localStorage.removeItem('isAuthenticated');
+      }
+    }
+  }, []);
+
+  const saveAuth = (authUser: User) => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('authUser', JSON.stringify(authUser));
+    localStorage.setItem('isAuthenticated', 'true');
+  };
+
+  const clearAuth = () => {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem('authUser');
+    localStorage.removeItem('isAuthenticated');
+  };
+
   const login = (email?: string, password?: string) => {
     // Mock login: In a real app, validate credentials
     console.log('Mock login with:', email, password); // email and password not used in mock
@@ -34,6 +64,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
     setUser(mockUser);
     setIsAuthenticated(true);
+    saveAuth(mockUser);
   };
 
   const signup = (userData: User) => {
@@ -41,11 +72,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     console.log('Mock signup with:', userData);
     setUser(userData);
     setIsAuthenticated(true);
+    saveAuth(userData);
   };
 
   const logout = () => {
     setUser(null);
     setIsAuthenticated(false);
+    clearAuth();
   };
 
   return (


### PR DESCRIPTION
## Summary
- persist auth state in localStorage
- restore auth state on initial load

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5b35d748323a3a1b7abbd909efa