### PR TITLE
Add LinkContext and integrate with dashboard

### DIFF
--- a/src/app/(main)/add-link/page.tsx
+++ b/src/app/(main)/add-link/page.tsx
@@ -4,6 +4,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react'; // For back button
 import Link from 'next/link'; // For back button
+import { useLinks } from '@/contexts/LinkContext';
 
 interface FormData {
   title: string;
@@ -15,16 +16,17 @@ interface FormData {
 export default function AddLinkPage() {
   const { register, handleSubmit, formState: { errors } } = useForm<FormData>();
   const router = useRouter();
-  // const { addLink } = useAuth(); // Assuming you might add 'addLink' to AuthContext later
+  const { addLink } = useLinks();
 
   const onSubmit: SubmitHandler<FormData> = (data) => {
     const processedData = {
       ...data,
       id: Date.now().toString(), // Simple unique ID
       tags: data.tags.split(',').map(tag => tag.trim()).filter(tag => tag !== ''), // Process tags
+      dueDate: data.dueDate || undefined,
     };
     console.log("Form Data Submitted:", processedData);
-    // addLink(processedData); // If you implement addLink in AuthContext
+    addLink(processedData);
     router.push('/dashboard');
   };
 

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -3,55 +3,13 @@
 import LinkCard from '@/components/LinkCard';
 import { PlusCircle } from 'lucide-react'; // For "Add New Link" button
 import Link from 'next/link'; // For "Add New Link" button
-
-// Mock Data for Links
-const mockLinks = [
-  {
-    id: '1',
-    title: 'CS70 Study Group Notes',
-    link: 'https://docs.google.com/document/d/example1/edit',
-    dueDate: '2024-09-01',
-    tags: ['academics', 'cs70', 'study notes'],
-  },
-  {
-    id: '2',
-    title: 'Math 54 Problem Set 3',
-    link: 'https://math.berkeley.edu/~course/math54/ps/ps3.pdf',
-    dueDate: '2024-08-20',
-    tags: ['homework', 'math54', 'urgent'],
-  },
-  {
-    id: '3',
-    title: 'Favorite Lo-fi Playlist',
-    link: 'https://open.spotify.com/playlist/example3',
-    tags: ['music', 'focus', 'lo-fi'],
-  },
-  {
-    id: '4',
-    title: 'Next.js Official Documentation',
-    link: 'https://nextjs.org/docs',
-    tags: ['development', 'nextjs', 'reference'],
-  },
-  {
-    id: '5',
-    title: 'Internship Application Portal',
-    link: 'https://example.com/careers/apply',
-    dueDate: '2024-07-30',
-    tags: ['career', 'internship', 'application'],
-  },
-  {
-    id: '6',
-    title: 'Recipe: Overnight Oats',
-    link: 'https://www.examplefoodblog.com/overnight-oats',
-    tags: ['food', 'recipe', 'breakfast'],
-  },
-];
+import { useLinks } from '@/contexts/LinkContext';
 
 export default function DashboardPage() {
-  // Mock handlers for card actions (optional, for future use)
+  const { links, removeLink } = useLinks();
+
   const handleDelete = (id: string) => {
-    console.log(`Delete link with id: ${id}`);
-    // Implement actual deletion logic here (e.g., update state, call API)
+    removeLink(id);
   };
 
   const handleEdit = (id: string) => {
@@ -69,14 +27,14 @@ export default function DashboardPage() {
         </Link>
       </div>
 
-      {mockLinks.length === 0 ? (
+      {links.length === 0 ? (
         <div className="text-center py-12">
           <p className="text-xl text-gray-600 mb-4">You haven&apos;t added any links yet.</p>
           <p className="text-gray-500">Click the &quot;Add New Link&quot; button to get started!</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {mockLinks.map((link) => (
+          {links.map((link) => (
             <LinkCard
               key={link.id}
               id={link.id}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { LinkProvider } from "@/contexts/LinkContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +27,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <LinkProvider>{children}</LinkProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/contexts/LinkContext.tsx
+++ b/src/contexts/LinkContext.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+export interface LinkItem {
+  id: string;
+  title: string;
+  link: string;
+  dueDate?: string;
+  tags: string[];
+}
+
+interface LinkContextType {
+  links: LinkItem[];
+  addLink: (link: LinkItem) => void;
+  removeLink: (id: string) => void;
+}
+
+const LinkContext = createContext<LinkContextType | undefined>(undefined);
+
+export const LinkProvider = ({ children }: { children: ReactNode }) => {
+  const [links, setLinks] = useState<LinkItem[]>([]);
+
+  const addLink = (link: LinkItem) => {
+    setLinks((prev) => [...prev, link]);
+  };
+
+  const removeLink = (id: string) => {
+    setLinks((prev) => prev.filter((l) => l.id !== id));
+  };
+
+  return (
+    <LinkContext.Provider value={{ links, addLink, removeLink }}>
+      {children}
+    </LinkContext.Provider>
+  );
+};
+
+export const useLinks = () => {
+  const context = useContext(LinkContext);
+  if (context === undefined) {
+    throw new Error("useLinks must be used within a LinkProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- create `LinkContext` to store links in client state
- add `LinkProvider` to root layout
- use `addLink` in AddLinkPage
- show links from context in DashboardPage

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5b5b36483238ddf0918df35d991