### PR TITLE
Update README to clarify npm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository uses **npm** to manage dependencies.
 
 ## Getting Started
 
-Install dependencies using [npm](https://www.npmjs.com/) and start the development server:
+Install dependencies using [npm](https://www.npmjs.com/) and start the development server. Using `yarn install` may result in a version mismatch error because this project specifies an `npm` package manager in `package.json`. If you prefer `yarn`, first run `corepack enable` so that the correct Yarn version is activated:
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- mention the package manager error when using `yarn`
- suggest enabling corepack for users who prefer yarn

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa74187c883239d4d728e5752426c