### PR TITLE
Improve QR scanning

### DIFF
--- a/src/app/(main)/scan-qr/page.tsx
+++ b/src/app/(main)/scan-qr/page.tsx
@@ -1,20 +1,96 @@
 "use client";
 
-import { Camera, UploadCloud, Zap } from 'lucide-react'; // Icons for visual cues
+import { Camera, UploadCloud, Zap } from 'lucide-react';
+import { useLinks } from '@/contexts/LinkContext';
+import { useRef, useState, useEffect } from 'react';
 
 export default function ScanQRPage() {
-  // Mock function for starting scan - in a real app, this would interact with a QR library
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [scanning, setScanning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [supported, setSupported] = useState(true);
+  const { addLink } = useLinks();
+
+  useEffect(() => {
+    if (!scanning) return;
+    if (typeof window === 'undefined' || !('BarcodeDetector' in window)) {
+      setSupported(false);
+      setError('BarcodeDetector not supported in this browser');
+      setScanning(false);
+      return;
+    }
+    let stream: MediaStream;
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' }
+        });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+          requestAnimationFrame(scan);
+        }
+      } catch (err) {
+        console.error(err);
+        setError('Unable to access camera');
+        setScanning(false);
+      }
+    };
+
+    const detector = 'BarcodeDetector' in window
+      ? new (window as any).BarcodeDetector({ formats: ['qr_code'] })
+      : null;
+
+    const scan = async () => {
+      if (!scanning || !detector || !videoRef.current || !canvasRef.current) return;
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      canvas.width = videoRef.current.videoWidth;
+      canvas.height = videoRef.current.videoHeight;
+      ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
+      try {
+        const barcodes = await detector.detect(canvas);
+        if (barcodes.length > 0) {
+          const value = barcodes[0].rawValue;
+          setResult(value);
+          setScanning(false);
+          stop();
+          if (/^https?:\/\//.test(value)) {
+            addLink({
+              id: Date.now().toString(),
+              title: value,
+              link: value,
+              tags: [],
+              dueDate: undefined
+            });
+          }
+          return;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+      requestAnimationFrame(scan);
+    };
+
+    const stop = () => {
+      if (stream) stream.getTracks().forEach((t) => t.stop());
+    };
+
+    start();
+    return stop;
+  }, [scanning, addLink]);
+
   const handleStartScan = () => {
-    console.log("Attempting to start QR scan...");
-    // Logic to activate camera and QR scanner would go here
-    alert("QR Scanning not implemented yet. Imagine the camera feed starting now!");
+    setResult(null);
+    setError(null);
+    setScanning(true);
   };
 
-  // Mock function for uploading QR image
   const handleUploadImage = () => {
-    console.log("Attempting to upload QR image...");
-    // Logic for file input and processing would go here
-    alert("QR Code image upload not implemented yet.");
+    alert('QR Code image upload not implemented yet.');
   };
 
   return (
@@ -22,28 +98,43 @@ export default function ScanQRPage() {
       <h1 className="text-4xl font-bold text-gray-800 mb-8">Scan QR Code</h1>
 
       <div className="w-full bg-white p-8 rounded-lg shadow-xl mb-8">
-        {/* Conceptual Camera View Section */}
         <div
-          className="aspect-square w-full max-w-md mx-auto bg-gray-900 rounded-lg flex flex-col items-center justify-center mb-6 shadow-inner overflow-hidden"
-          aria-label="QR Code scanner camera feed placeholder"
+          className="aspect-square w-full max-w-md mx-auto bg-gray-900 rounded-lg flex flex-col items-center justify-center mb-6 shadow-inner overflow-hidden relative"
         >
-          <Camera size={64} className="text-gray-500 mb-4" />
-          <p className="text-gray-400 text-lg font-medium">Camera feed will appear here.</p>
-          <div className="absolute w-3/4 h-3/4 border-4 border-dashed border-gray-400 opacity-50 rounded-md"></div>
+          {scanning ? (
+            <>
+              <video ref={videoRef} className="w-full h-full object-cover" />
+              <canvas ref={canvasRef} className="hidden" />
+            </>
+          ) : (
+            <>
+              <Camera size={64} className="text-gray-500 mb-4" />
+              <p className="text-gray-400 text-lg font-medium">Camera feed will appear here.</p>
+            </>
+          )}
+          <div className="absolute w-3/4 h-3/4 border-4 border-dashed border-gray-400 opacity-50 rounded-md pointer-events-none"></div>
         </div>
 
-        <p className="text-center text-gray-600 mb-6 text-sm">
-          Position the QR code clearly within the frame for a quick scan.
-        </p>
+        {error && <p className="text-red-600 text-center mb-2">{error}</p>}
+        {!supported && (
+          <p className="text-center text-red-600 mb-2">
+            Barcode scanning is not supported in this browser
+          </p>
+        )}
+        {result && (
+          <p className="text-center text-green-600 font-semibold mb-2 break-all">
+            Detected: {result}
+          </p>
+        )}
 
-        {/* Action Buttons */}
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <button
             onClick={handleStartScan}
             className="flex items-center justify-center w-full sm:w-auto bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg shadow-md hover:shadow-lg transition duration-300 ease-in-out"
+            disabled={scanning || !supported}
           >
             <Zap size={20} className="mr-2" />
-            Start Scan
+            {scanning ? 'Scanning...' : 'Start Scan'}
           </button>
           <button
             onClick={handleUploadImage}


### PR DESCRIPTION
## Summary
- handle browsers without `BarcodeDetector`
- display unsupported message and disable scan button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fad7665ec83238d09617442cc3049